### PR TITLE
docs: add contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,25 @@
+# Contributing Guide
+
+Thank you for helping improve Frontend Mastery Hub! This document outlines the process for adding code or curriculum content to the repository.
+
+## Branching Strategy
+- Develop on dedicated branches created from `main`.
+- Use descriptive branch names such as `feat/topic-name` or `fix/bug-description`.
+- Avoid committing directly to `main`; all work should land via pull requests.
+
+## Commit Style
+- Follow [Conventional Commits](https://www.conventionalcommits.org/) for commit messages (e.g., `feat: add react router lesson`).
+- Keep messages concise and focused on a single change.
+- Run relevant checks before committing to ensure the repository remains stable.
+
+## Review Process
+- Open a pull request once your branch is ready and ensure all checks pass.
+- At least one reviewer must approve before merging.
+- Address feedback promptly and keep discussions in the pull request thread.
+
+## Curriculum Alignment
+- All educational content must align with the existing dual-track curriculum.
+- Reference the **Curriculum Structure** in the `README.md` when proposing new modules, noting the track (Core or Extended), phase, and level where the content fits.
+- Ensure submissions complement existing material and maintain the roadmap outlined in `Roadmap.md`.
+
+By following these guidelines, contributors can help keep the project organized and aligned with its learning goals. Happy contributing!


### PR DESCRIPTION
## Summary
- add CONTRIBUTING.md outlining branching strategy and commit style
- document review expectations and aligning content with curriculum structure

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689637c586dc8321a2014098eddaaeb9